### PR TITLE
Inserted fix in case there is a duplicate function or subroutine

### DIFF
--- a/VBSdoc.vbs
+++ b/VBSdoc.vbs
@@ -646,7 +646,11 @@ Private Function GetMethodDef(ByRef code, ByVal includePrivate)
 				d.Add "Metadata", tags
 
 				log.LogDebug "Adding procedure/function " & .Item(7)
-				methods.Add .Item(7), d
+				if ( methods.exists( .Item(7) ) ) Then
+					log.LogDebug "> Found duplicate " & .Item(7)
+				Else
+					methods.Add .Item(7), d
+				End If
 			End If
 		End With
 	Next


### PR DESCRIPTION
If there is a duplicate function or subroutine name, the script will error out. 

The fix will find the duplicate, log and ignore it, and if it's not a duplicate, it will add it to methods. 

What do you think of the fix?
